### PR TITLE
fix: error with parsing comma

### DIFF
--- a/mecabpr/mecabpr.py
+++ b/mecabpr/mecabpr.py
@@ -21,9 +21,23 @@ class MeCabPosRegex:
             string = string.replace(i, "({})".format(j))
         return string
 
+    def split_tagline(self, t):
+        if len(t.split("\t")) == 2:
+            surface, features = t.split("\t")
+            if len(features.split(",")) > 1:
+                features = features.split(",")
+            elif len(features.split("|")) > 1:
+                features = features.split("|")
+            else:
+                features = [features]
+            return [surface] + features
+        else:
+            print("ERROR: invalid tagline")
+            raise
+
     def findall(self, string, pattern, raw=False):
         pos_raw = [t for t in self.tagger.parse(string).split("\n") if "\t" in t]
-        pos_raw_list = [re.split(r',|\t', t) for t in pos_raw]
+        pos_raw_list = [self.split_tagline(t) for t in pos_raw]
 
         # convert string into id sequence
         pos_seq = self.convert_string(pos_raw_list)

--- a/tests/test_posregex.py
+++ b/tests/test_posregex.py
@@ -85,6 +85,9 @@ def test_sentnece_01_raw():
     assert mpr.findall(sentence, "名詞名詞", raw=True) == [['すべて\t名詞,副詞可能,*,*,*,*,すべて,スベテ,スベテ',
                                                         '自分\t名詞,一般,*,*,*,*,自分,ジブン,ジブン']]
 
+    assert mpr.findall("1,000", "名詞", raw=True) == [["1\t名詞,数,*,*,*,*,*"],
+                                                    [",\t名詞,サ変接続,*,*,*,*,*"],
+                                                    ["000\t名詞,数,*,*,*,*,*"]]
 
 def test_neologd():
     mpr = MeCabPosRegex()


### PR DESCRIPTION
- 以下のように `,` の含まれる文字列のパースで落ちる:

```python
>>> mpr.findall("1,000", "名詞", raw=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../python3.7/site-packages/mecabpr/mecabpr.py", line 29, in findall
    pos_seq = self.convert_string(pos_raw_list)
  File ".../lib/python3.7/site-packages/mecabpr/mecabpr.py", line 17, in convert_string
    return "".join([pos2id[p] for p in pos_list])
  File ".../lib/python3.7/site-packages/mecabpr/mecabpr.py", line 17, in <listcomp>
    return "".join([pos2id[p] for p in pos_list])
KeyError: '-名詞-サ変接続-*'
```

- 修正後、testを追加, seup.py install, 動作確認した